### PR TITLE
Cap trust anchor IDs to 255 bytes

### DIFF
--- a/draft-beck-tls-trust-anchor-ids.md
+++ b/draft-beck-tls-trust-anchor-ids.md
@@ -185,6 +185,8 @@ Depending on the protocol, trust anchor identifiers may be represented in one of
 
 Trust anchor identifiers SHOULD be allocated by the CA operator and common among relying parties that trust the CA. They MAY be allocated by another party, e.g. when bootstrapping an existing ecosystem, if all parties agree on the identifier. In particular, the protocol requires relying parties and subscribers to agree, and subscriber configuration typically comes from the CA.
 
+The length of a trust anchor identifier's binary representation MUST NOT exceed 255 bytes. It SHOULD be significantly shorter, for bandwidth efficiency.
+
 ## Certificate Properties {#certificate-properties}
 
 This document introduces an extensible CertificatePropertyList structure for CAs to communicate additional information to subscribers, such as associated trust anchor identifiers. A CertificatePropertyList is defined using the TLS presentation language ({{Section 3 of !RFC8446}}) below:


### PR DESCRIPTION
So that the 1-byte length prefix works. Fixes #65. 255 bytes should be far more than enough; if you're anywhere near that, you could have just used a SHA-256 hash of something.

(Admittedly, the OID idea does not lend itself well to SHA-256 hashes. You can encode them but it's a little fussy. Probably the most straightforward is to use 37 7-bit components.)