### PR TITLE
Trim the ACME section a bit

### DIFF
--- a/draft-beck-tls-trust-anchor-ids.md
+++ b/draft-beck-tls-trust-anchor-ids.md
@@ -339,16 +339,6 @@ If doing so, the client MAY send a subset of this intersection to meet size cons
 
 Although this service parameter is intended to reduce trust anchor mismatches, mismatches may still occur in some scenarios. Clients and servers MUST continue to implement the provisions described in {{retry-mechanism}}, even when using this service parameter.
 
-# ACME Extension
-
-This section extends ACME {{!RFC8555}} to be able to issue certificate paths, each with an associated CertificatePropertyList by defining a new media type in {{media-type}}.
-
-When an ACME server processes an order object, it MAY issue multiple certification paths, each with an associated Trust Anchor Identifier. The ACME server encodes each certification path using the application/pem-certificate-chain-with-properties format, defined in {{media-type}}).  Note this format is required to form a complete certification path. The CA MUST return a result that may be verified by relying parties without path building {{?RFC4158}}.
-
-The ACME server provides additional results to the client with the link relation header fields described in {{Section 7.4.2 of !RFC8555}}. When fetching certificates, the ACME client includes application/pem-certificate-chain-with-properties in its Accept header to indicate it supports the new format. Unlike the original mechanism described in {{RFC8555}}, these certification paths do not require heuristics to be used. Instead, the server uses the associated Trust Anchor Identifiers to select a path when requested.
-
-When the ACME client wishes to renew any of the certification paths issued in this order, it repeats this process to renew each path concurrently. Thus this extension is suitable when the CA is willing to issue and renew all paths together. It may not be appropriate if the paths have significantly different processing times or lifetimes. Future enhancements to ACME may be defined to address these cases, e.g. by allowing the ACME client to make independent orders.
-
 # Media Type
 
 A certification path with its associated CertificationPropertyList may be represented in a PEM {{!RFC7468}} structure in a file of type "application/pem-certificate-chain-with-properties". Files of this type MUST use the strict encoding and MUST NOT include explanatory text.  The ABNF {{!RFC5234}} for this format is
@@ -383,6 +373,16 @@ TODO fill in an example
 ~~~
 
 The IANA registration for this media type is described in {{media-type-updates}}.
+
+# ACME Extension
+
+This section extends ACME {{!RFC8555}} to be able to issue certificate paths, each with an associated CertificatePropertyList by defining a new media type in {{media-type}}.
+
+When an ACME server processes an order object, it MAY issue multiple certification paths, each with an associated Trust Anchor Identifier. The ACME server encodes each certification path using the application/pem-certificate-chain-with-properties format, defined in {{media-type}}).  Note this format is required to form a complete certification path. The CA MUST return a result that may be verified by relying parties without path building {{?RFC4158}}.
+
+The ACME server provides additional results to the client with the link relation header fields described in {{Section 7.4.2 of !RFC8555}}. When fetching certificates, the ACME client includes application/pem-certificate-chain-with-properties in its Accept header to indicate it supports the new format. Unlike the original mechanism described in {{RFC8555}}, these certification paths do not require heuristics to be used. Instead, the server uses the associated Trust Anchor Identifiers to select a path when requested.
+
+When the ACME client wishes to renew any of the certification paths issued in this order, it repeats this process to renew each path concurrently. Thus this extension is suitable when the CA is willing to issue and renew all paths together. It may not be appropriate if the paths have significantly different processing times or lifetimes. Future enhancements to ACME may be defined to address these cases, e.g. by allowing the ACME client to make independent orders.
 
 # Use Cases
 

--- a/draft-beck-tls-trust-anchor-ids.md
+++ b/draft-beck-tls-trust-anchor-ids.md
@@ -233,7 +233,7 @@ Relying parties MAY support trust anchors without associated trust anchor identi
 
 Authenticating parties are configured with one or more candidate certification paths to present in TLS, in some preference order. This preference order is used when multiple candidate paths are usable for a connection. For example, the authenticating party may prefer candidates that minimize message size or have more performant private keys.
 
-Each candidate path which participates in this protocol must be provisioned with the trust anchor identifier for its corresponding trust anchor in the CertificatePropertlyList.
+Each candidate path which participates in this protocol must be provisioned with the trust anchor identifier for its corresponding trust anchor in the CertificatePropertyList.
 
 Authenticating parties MAY have candidate certification paths without associated trust anchor identifiers, but such paths will not participate in this protocol. Those paths MAY participate in other trust anchor negotiation protocols, such as the `certificate_authorities` extension.
 

--- a/draft-beck-tls-trust-anchor-ids.md
+++ b/draft-beck-tls-trust-anchor-ids.md
@@ -341,7 +341,7 @@ Although this service parameter is intended to reduce trust anchor mismatches, m
 
 # Provisioning Certificates
 
-While, this document does not prescribe a specific configuration format or provisioning process, this section defines optional extensions to aid TLS applications using PEM {{!RFC7468}} or ACME {{!RFC8555}}.
+While this document does not prescribe a specific configuration format or provisioning process, this section defines optional extensions to aid TLS applications using PEM {{!RFC7468}} or ACME {{!RFC8555}}.
 
 ## Media Type
 


### PR DESCRIPTION
Based on feedback from @aarongable, let's just define the media type and how to use it with the existing ACME mechanisms. In particular, the alternate chain mechanism is not quite ideal for parallel issuance. Parallel issuance can be better solved in a separate document, as it's really orthogonal to the exact trust anchor negotiation strategy.

There's probably other bits we can trim, but I've left them alone for now.