### PR TITLE
Slight tweak to wording of X.509 extension

### DIFF
--- a/draft-beck-tls-trust-anchor-ids.md
+++ b/draft-beck-tls-trust-anchor-ids.md
@@ -195,7 +195,7 @@ Authenticating parties MUST ignore properties with unrecognized CertificatePrope
 
 Relying parties are configured with one or more supported trust anchors. Each trust anchor which participates in this protocol must have an associated trust anchor identifier.
 
-When trust anchors are self-signed X.509 certificates, the X.509 trust anchor identifier extension MAY be used to carry this identifier. The trust anchor identifier extension has an `extnID` of `id-trustAnchorIdentifier` and an `extnValue` containing a DER-encoded TrustAnchorIdentifier structure, defined below. The TrustAnchorIdentifier is the trust anchor identifier's ASN.1 representation, described in {{trust-anchor-ids}}. This extension MUST be non-critical.
+When trust anchors are represented as X.509 certificates, the X.509 trust anchor identifier extension MAY be used to carry this identifier. The trust anchor identifier extension has an `extnID` of `id-trustAnchorIdentifier` and an `extnValue` containing a DER-encoded TrustAnchorIdentifier structure, defined below. The TrustAnchorIdentifier is the trust anchor identifier's ASN.1 representation, described in {{trust-anchor-ids}}. This extension MUST be non-critical.
 
 ~~~
 id-trustAnchorIdentifier OBJECT IDENTIFIER ::= { TBD }


### PR DESCRIPTION
I think it's better to say the trust anchor is *represented* as an X.509 certificate rather than that it *is* an X.509 certificate. You might represent the "same" trust anchor in different ways. RFC 5280 doesn't do a great job of nailing this down.

Also drop the "self-signed" because it might be, e.g., draft-davidben-x509-alg-none. (But I don't think it actually makes sense to cite that draft, so just leave it unspecified.)