### PR TITLE
Fix the definition of a trust anchor

### DIFF
--- a/draft-beck-tls-trust-anchor-ids.md
+++ b/draft-beck-tls-trust-anchor-ids.md
@@ -144,7 +144,7 @@ Certification authority (CA):
 Additionally, there are several terms used throughout this document to describe this proposal:
 
 Trust anchor:
-: A pre-distributed public key or certificate that relying parties use to determine whether a certification path is trusted.
+: A pre-distributed X.509 name and public key that relying parties use to determine whether a certification path is trusted. See {{Section 6.1.1 of !RFC5280}}. Trust anchors are sometimes configured as self-signed certificates.
 
 Certification path:
 : An ordered list of X.509 certificates starting with the target certificate. Each certificate is issued by the next certificate, except the last, which is issued by a trust anchor.


### PR DESCRIPTION
Prompted by chatting with @bwesterb

A trust anchor is not just a pre-distributed key. It also, at minimum, includes the name. It is also not a self-signed certificate. Self-signed certificates are just a common way to specify them. Just cite the definition from RFC 5280.

An astute reader of RFC 5280 might notice that this implies no other properties of the root certificate (when using one) matter. This is... complicated.  Path validation takes a bunch of extra things as inputs. RFC 5937 discusses how to fill in those parameters from other values in the root certificate. This means, formally, a trust anchor is just the name and key, and then any other constraints the application applies are just decisions it made in how to set those other inputs. Those inputs don't cover all application behaviors in practice. You can think of this as application-specific extensions of Section 6.1 to add more inputs to the process.

We don't current discuss or handle those specifically. Possibly worth some discussion, but I'll leave that for a separate PR. Broadly, the answers there are:

- The CA should mostly know what constraints its under and should mostly not issue certs incompatible with that

- If it does, the retry flow allows the client to ask for a new cert and try again